### PR TITLE
Fixed: Broken test scenarios related to `pytest.raises`

### DIFF
--- a/challenge/tests/test_arg_checker.py
+++ b/challenge/tests/test_arg_checker.py
@@ -1,7 +1,7 @@
 from arg_checker import arg_checker
 import pytest
 
-arg_checker(int, int, int)
+@arg_checker(int, int, int)
 def adder(a, b, c):
     '''Returns the sum of the arguments'''
     return a + b + c
@@ -10,7 +10,7 @@ def test_correct_args():
     assert adder(1, 2, 3) == 6
 
 def test_incorrect_number_of_args():
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError): 
         adder(1, 2)
 
     with pytest.raises(TypeError):

--- a/challenge/tests/test_arg_checker.py
+++ b/challenge/tests/test_arg_checker.py
@@ -12,12 +12,18 @@ def test_correct_args():
 def test_incorrect_number_of_args():
     with pytest.raises(TypeError):
         adder(1, 2)
+
+    with pytest.raises(TypeError):
         adder(1, 2, 3, 4)
 
 def test_type_of_args():
-    with pytest.raises(TypeError): 
+    with pytest.raises(TypeError):
         adder('1', 2, 3)
+
+    with pytest.raises(TypeError):
         adder(1, 2.0, 3)
+        
+    with pytest.raises(TypeError):
         adder(1, 2, '3')
 
 def test_decorated_function():

--- a/challenge/tests/test_linkedin_checker.py
+++ b/challenge/tests/test_linkedin_checker.py
@@ -9,24 +9,36 @@ def test_correct_custom_url():
     assert check_linkedin_feature('jonfernandes2000', 'custom_url')
     assert check_linkedin_feature('JonathanFernandes', 'custom_url')
     assert check_linkedin_feature('JonathanFernandes2000', 'custom_url')
+    # atleast 3 characters
+    assert check_linkedin_feature('jof', 'custom_url')
+    # atmost 100 characters
+    assert check_linkedin_feature('jonathanafernandes20' + '0' * 80, 'custom_url')
 
 def test_incorrect_custom_url():
     assert check_linkedin_feature('jonathanafernande$', 'custom_url') == False
     assert check_linkedin_feature('jon-fernandes2000', 'custom_url') == False
     assert check_linkedin_feature('Jonathan_Fernandes', 'custom_url') == False
     assert check_linkedin_feature('JonathanFernandes2000!!', 'custom_url') == False
-
+    # less than 3 characters
+    assert check_linkedin_feature('jf', 'custom_url') == False
+    # valid regex more than 100 characters
+    assert check_linkedin_feature('jonathanafernandes20' + '0' * 81, 'custom_url') == False
+    
 def test_correct_email():
     assert check_linkedin_feature('jf@gmail.com', 'login')
     assert check_linkedin_feature('jonathanfernandes@gmail.com', 'login')
     assert check_linkedin_feature('jonathan-fernandes@gmail.com', 'login')
     assert check_linkedin_feature('jonathan_fernandes@gmail.com', 'login')
     assert check_linkedin_feature('jonathan.fernandes@gmail.com', 'login')
+    # atmost 50 characters
+    assert check_linkedin_feature(f'jonathanfernandes{"0" * 23}@gmail.com', 'login')
 
 def test_incorrect_email():
     assert check_linkedin_feature('jonathangmail.com', 'login') == False
     assert check_linkedin_feature('jonathanfernandes@gmail.biz', 'login') == False
     assert check_linkedin_feature('jonathanfernandes@gmail.co.uk', 'login') == False
+    # valid email regex but more than 50 characters
+    assert check_linkedin_feature(f'jonathanfernandes{"0" * 24}@gmail.com', 'login') == False
 
 def test_incorrect_feature():
     with pytest.raises(ValueError):


### PR DESCRIPTION
#### 1. Fixed broken test cases for `arg_checker` challenge
Assertions are not being executed because the function calls to `adder` are not enclosed in separate `pytest.raises` blocks.

#### 2. Added missing boundary test cases for `linkedin_checker` challenge